### PR TITLE
Update3

### DIFF
--- a/scripts/vscripts/swarm.nut
+++ b/scripts/vscripts/swarm.nut
@@ -5,11 +5,14 @@ swarmMode <- "swarm";
 ///////////////////////////////////////////////
 //              INCLUDE SCRIPTS              //
 ///////////////////////////////////////////////
+IncludeScript("swarm/swarm_globals");
 IncludeScript("swarm/swarm_stocks");
+IncludeScript("swarm/swarm_game_events");
 IncludeScript("swarm/swarm_corruption");
 IncludeScript("swarm/swarm_breaker");
 IncludeScript("swarm/swarm_specials");
 IncludeScript("swarm/swarm_commons");
 IncludeScript("swarm/swarm_hazards");
 IncludeScript("swarm/swarm_ping");
+IncludeScript("swarm/swarm_playercards_stocks");
 IncludeScript("swarm/swarm_playercards");

--- a/scripts/vscripts/swarm/swarm_breaker.nut
+++ b/scripts/vscripts/swarm/swarm_breaker.nut
@@ -1,10 +1,6 @@
 ///////////////////////////////////////////////
 //               SWARM CIRCLE                //
 ///////////////////////////////////////////////
-bSwarmCircleActive <- false;
-swarmTickTime <- 0;
-swarmOrigin <- null;
-
 if (!IsModelPrecached("models/swarm/swarmcircle.mdl"))
 	PrecacheModel("models/swarm/swarmcircle.mdl");
 
@@ -14,7 +10,7 @@ function TankDeath()
 	DestroyTankHud();
 }
 
-function OnGameEvent_player_team(params)
+function TankKicked(params)
 {
 	// Called when a tank is kicked
 	if (Director.IsTankInPlay() == false)
@@ -86,7 +82,6 @@ function KillSwarmCircle()
 	bSwarmCircleActive = false;
 }
 
-safeSurvivors <- array(4);
 function SwarmCircleApplyDamage()
 {
 	if ((Time() - swarmTickTime) >= swarmTickInterval || swarmTickTime == 0)
@@ -133,13 +128,14 @@ function SwarmCircleApplyDamage()
 ///////////////////////////////////////////////
 //               BREAKER JUMP                //
 ///////////////////////////////////////////////
-if (!IsSoundPrecached("player\\tank\\voice\\pain\\tank_fire_06.wav"))
-	PrecacheSound("player\\tank\\voice\\pain\\tank_fire_06.wav");
+if (!IsSoundPrecached("player/tank/voice/pain/tank_fire_06.wav"))
+	PrecacheSound("player/tank/voice/pain/tank_fire_06.wav");
 
 function BreakerJump(player)
 {
 	if (bossBreakerEnable == true)
 	{
+		//Apply the jump
 		local eyeAngles = player.EyeAngles();
 		local verticalVelocity = sin(DegToRad(Clamp(eyeAngles.x, 0) * -1)) * tankJumpExtraHeight;
 		local verticalOffset = (1.15 - (verticalVelocity / tankJumpExtraHeight))
@@ -149,18 +145,16 @@ function BreakerJump(player)
 			(tankJumpVelocity * sin(DegToRad(eyeAngles.y))) * verticalOffset,
 			300 + verticalVelocity));
 
-		// Stagger to stop the rock
-		
+		//Stagger to stop the rock
+		local staggerDuration = Convars.GetFloat("z_max_stagger_duration");
+		printl(staggerDuration)
+		Convars.SetValue("z_max_stagger_duration", 1);
 		player.Stagger(Vector(0, 0, 0));
-		/*local rock = null;
-		while ((rock = Entities.FindByClassname(rock, "tank_rock")) != null)
-		{
-			rock.Kill();
-		}*/
+		Convars.SetValue("z_max_stagger_duration", staggerDuration);
 
 		if (bSwarmCircleActive == false)
 		{
-			EmitSoundOn("player\\tank\\voice\\pain\\tank_fire_06.wav", player)
+			EmitSoundOn("player/tank/voice/pain/tank_fire_06.wav", player)
 		}
 
 		CreateSwarmCircle(player);
@@ -197,10 +191,7 @@ function CancelRockAnimation()
 ///////////////////////////////////////////////
 //                HEALTH HUD                 //
 ///////////////////////////////////////////////
-bTankHudExists <- false;
-tankHudTankID <- null;
-
-function OnGameEvent_tank_spawn(params)
+function TankSpawn(params)
 {
 	if (!bTankHudExists)
 	{

--- a/scripts/vscripts/swarm/swarm_commons.nut
+++ b/scripts/vscripts/swarm/swarm_commons.nut
@@ -1,13 +1,7 @@
 ///////////////////////////////////////////////
 //            SHARED COMMON EVENTS           //
 ///////////////////////////////////////////////
-commonVarList <- array(50, null);
-acidCommonsCount <- 0;
-fireCommonsCount <- 0;
-explodingCommonsCount <- 0;
-uncommonsCount <- 0;
-
-function OnGameEvent_zombie_death(params)
+function ZombieDeath(params)
 {
 	if ("victim" in params)
 	{
@@ -17,17 +11,17 @@ function OnGameEvent_zombie_death(params)
 		{
 			local commonName = common.GetName();
 
-			if (commonName.find("__acid_common_inst_") != null)
+			if (commonName.find("__acid_common") != null)
 			{
 				DropSpit(common.GetOrigin());
 				EntFire(commonName + "spitTrail", "Kill");
 			}
-			else if (commonName.find("__fire_common_inst_") != null)
+			else if (commonName.find("__fire_common") != null)
 			{
 				EntFire(commonName + "fireTrail", "Kill");
 				EntFire(commonName + "fireDamage", "Kill");
 			}
-			else if (commonName.find("__expl_common_inst_") != null)
+			else if (commonName.find("__expl_common") != null)
 			{
 				EntFire(commonName + "explProp", "Kill");
 				EntFire(commonName + "explHitbox", "Kill");
@@ -72,15 +66,15 @@ function BuildCommonList()
 					commonVarList.append(common);
 				}
 			}
-			if (commonName.find("__acid_common_inst_") != null)
+			if (commonName.find("__acid_common") != null)
 			{
 				acidCommonsCount++;
 			}
-			else if (commonName.find("__fire_common_inst_") != null)
+			else if (commonName.find("__fire_common") != null)
 			{
 				fireCommonsCount++;
 			}
-			else if (commonName.find("__expl_common_inst_") != null)
+			else if (commonName.find("__expl_common") != null)
 			{
 				explodingCommonsCount++;
 			}
@@ -96,8 +90,6 @@ function BuildCommonList()
 ///////////////////////////////////////////////
 //                ACID COMMONS               //
 ///////////////////////////////////////////////
-acidCommonsTimer <- 0;
-
 function AcidCommonsCountdown()
 {
 	if ((Time() - acidCommonsTimer) >= acidCommonSpawnRate)
@@ -119,7 +111,7 @@ function AcidCommonsCountdown()
 
 function CreateAcidCommon(common)
 {
-	local commonName = "__acid_common_inst_" + common.GetEntityIndex();
+	local commonName = "__acid_common" + common.GetEntityIndex();
 	DoEntFire("!self", "AddOutput", "targetname " + commonName, 0, common, common);
 
 	local spitTrail = SpawnEntityFromTable("info_particle_system",
@@ -138,8 +130,6 @@ function CreateAcidCommon(common)
 ///////////////////////////////////////////////
 //                FIRE COMMONS               //
 ///////////////////////////////////////////////
-fireCommonsTimer <- 1;
-
 function FireCommonsCountdown()
 {
 	if ((Time() - fireCommonsTimer) >= fireCommonSpawnRate)
@@ -161,7 +151,7 @@ function FireCommonsCountdown()
 
 function CreateFireCommon(common)
 {
-	local commonName = "__fire_common_inst_" + common.GetEntityIndex();
+	local commonName = "__fire_common" + common.GetEntityIndex();
 	DoEntFire("!self", "AddOutput", "targetname " + commonName, 0, common, common);
 
 	local spitTrail = SpawnEntityFromTable("info_particle_system",
@@ -200,9 +190,6 @@ function CreateFireCommon(common)
 ///////////////////////////////////////////////
 if (!IsModelPrecached("models/swarm/propanecanister001a_head.mdl"))
 	PrecacheModel("models/swarm/propanecanister001a_head.mdl");
-
-explodingCommonsTimer <- 3;
-explodingCommonsFiltersExist <- false;
 
 function ExplodingCommonsFilters()
 {
@@ -255,7 +242,7 @@ function ExplodingCommonsCountdown()
 
 function CreateExplodingCommon(common)
 {
-	local commonName = "__expl_common_inst_" + common.GetEntityIndex();
+	local commonName = "__expl_common" + common.GetEntityIndex();
 	DoEntFire("!self", "AddOutput", "targetname " + commonName, 0, common, common);
 
 	local commonOrigin = common.GetOrigin();
@@ -349,8 +336,6 @@ function ExplodingCommonBoom(common)
 ///////////////////////////////////////////////
 //                 UNCOMMONS                 //
 ///////////////////////////////////////////////
-uncommonsTimer <- 0;
-
 function ClownCountdown()
 {
 	if ((Time() - uncommonsTimer) >= uncommonSpawnRate)

--- a/scripts/vscripts/swarm/swarm_game_events.nut
+++ b/scripts/vscripts/swarm/swarm_game_events.nut
@@ -1,0 +1,180 @@
+///////////////////////////////////////////////
+//                GAME EVENTS                //
+///////////////////////////////////////////////
+//Put all game event functions here, if used in multiple places create function that is called inside the event here
+
+//Tank
+function OnGameEvent_player_team(params)
+{
+	TankKicked(params);
+}
+
+function OnGameEvent_tank_spawn(params)
+{
+	TankSpawn(params);
+}
+
+//Common Infected
+function OnGameEvent_zombie_death(params)
+{
+	ZombieDeath(params);
+}
+
+//Player Cards
+function OnGameEvent_map_transition(params)
+{
+	MapTransition(params);
+}
+
+function OnGameEvent_round_freeze_end(params)
+{
+	RoundFreezeEnd(params);
+}
+
+function OnGameEvent_round_start_post_nav(params)
+{
+	RoundStartPostNav(params);
+}
+
+function OnGameEvent_player_first_spawn(params)
+{
+	GetAllPlayerCards();
+}
+
+function OnGameEvent_weapon_reload(params)
+{
+	WeaponReload(params);
+}
+
+//Specials
+function OnGameEvent_ability_use(params)
+{
+	local player = GetPlayerFromUserID(params["userid"]);
+	local ability = params["ability"];
+
+	switch(ability)
+	{
+		case "ability_throw":
+			BreakerJump(player);
+		break;
+		case "ability_vomit":
+			ExploderAbility(player);
+		break;
+		case "ability_lunge":
+			SleeperLunge(player);
+		break;
+		default:
+		break;
+	}
+}
+
+function OnGameEvent_tongue_grab(params)
+{
+	TongueGrab(params);
+	CappedAlert();
+}
+
+function OnGameEvent_witch_harasser_set(params)
+{
+	SnitchAlerted(params);
+}
+
+function OnGameEvent_lunge_pounce(params)
+{
+	SleeperLanded(params);
+	CappedAlert();
+}
+
+function OnGameEvent_player_now_it(params)
+{
+	RetchVomitHit(params);
+}
+
+function OnGameEvent_jockey_ride(params)
+{
+	CappedAlert();
+}
+
+function OnGameEvent_charger_carry_start(params)
+{
+	CappedAlert();
+}
+
+//Stocks
+function OnGameEvent_player_spawn(params)
+{
+	PlayerSpawn(params);
+}
+
+function OnGameEvent_player_death(params)
+{
+	PlayerDeath(params);
+}
+
+function OnGameEvent_player_incapacitated_start(params)
+{
+	ApplyAdrenalineRush();
+	ApplyInspiringSacrifice();
+}
+
+function OnGameEvent_round_start(params)
+{
+	RoundStart(params);
+}
+
+function OnGameEvent_player_activate(params)
+{
+	CorruptionDropItems();
+}
+
+function OnGameEvent_player_left_safe_area(params)
+{
+	PlayerLeftSafeArea(params);
+}
+
+function OnGameEvent_player_hurt(params)
+{
+	PlayerHurt(params);
+}
+
+function OnGameEvent_heal_begin(params)
+{
+	HealBegin(params);
+}
+
+function OnGameEvent_heal_success(params)
+{
+	HealSuccess(params);
+}
+
+function OnGameEvent_pills_used(params)
+{
+	PillsUsed(params);
+}
+
+function OnGameEvent_adrenaline_used(params)
+{
+	AdrenalineUsed(params);
+}
+
+function OnGameEvent_revive_success(params)
+{
+	ReviveSuccess(params);
+}
+
+function OnGameEvent_triggered_car_alarm(params)
+{
+	Heal_AmpedUp();
+}
+
+function OnGameEvent_player_shoved(params)
+{
+	SleeperShoved(params);
+}
+
+function OnGameEvent_item_pickup(params)
+{
+	TallboySpawn(params);
+	SurvivorPickupItem(params);
+	InitOptics(params);
+}

--- a/scripts/vscripts/swarm/swarm_globals.nut
+++ b/scripts/vscripts/swarm/swarm_globals.nut
@@ -1,0 +1,309 @@
+///////////////////////////////////////////////
+//            GLOBALS / CONSTANTS            //
+///////////////////////////////////////////////
+//Globals
+difficulty <- GetDifficulty();
+survivorSet <- Director.GetSurvivorSet();
+z_speed <- Convars.GetFloat("z_speed");
+
+//Breaker
+bSwarmCircleActive <- false;
+swarmTickTime <- 0;
+swarmOrigin <- null;
+safeSurvivors <- array(4);
+
+//Tank HUD
+bTankHudExists <- false;
+tankHudTankID <- null;
+
+//Commons
+commonVarList <- array(50, null);
+acidCommonsCount <- 0;
+fireCommonsCount <- 0;
+explodingCommonsCount <- 0;
+uncommonsCount <- 0;
+acidCommonsTimer <- 0;
+fireCommonsTimer <- 1;
+explodingCommonsTimer <- 3;
+explodingCommonsFiltersExist <- false;
+uncommonsTimer <- 0;
+
+//Corruption
+corruptionCards <- array(1, null);
+corruptionCommons <- null;
+corruptionUncommons <- null;
+corruptionZSpeed <- null;
+corruptionTallboy <- null;
+corruptionHocker <- null;
+corruptionRetch <- null;
+corruptionHazards <- null;
+corruptionBoss <- null;
+corruptionEnvironmental <- null;
+corruptionHordes <- null;
+corruptionGameplay <- null;
+corruptionPlayer <- null;
+
+//Corruption - Specials
+TallboyHordeEnabled <- false;
+CrusherHordeEnabled <- false;
+BruiserHordeEnabled <- false;
+StalkerHordeEnabled <- false;
+HockerHordeEnabled <- false;
+ExploderHordeEnabled <- false;
+RetchHordeEnabled <- false;
+SpecialHordeTimer <- null;
+
+//Corruption - Frigid Outskirts
+frigidOutskirtsEnabled <- false;
+frigidOutskirtsStormActive <- false;
+frigidOutskirtsCalmTime <- 90;
+frigidOutskirtsStormTime <- 20;
+frigidOutskirtsTimer <- 0;
+
+//Corruption - Hunted
+HuntedEnabled <- false;
+HuntedTimer <- null;
+
+//Corruption - Onslaught
+OnslaughtEnabled <- false;
+OnslaughtTimer <- null;
+
+//Ammo
+ammoShortageMultiplier <- 0.7;
+ammo_assaultrifle_max <- 360;
+ammo_autoshotgun_max <- 90;
+ammo_huntingrifle_max <- 150;
+ammo_shotgun_max <- 72;
+ammo_smg_max <- 650;
+ammo_sniperrifle_max <- 180;
+
+//Use Speed
+sluggishMultiplier <- 1.5;
+ammo_pack_use_duration <- 3;
+cola_bottles_use_duration <- 1.95;
+defibrillator_use_duration <- 3;
+first_aid_kit_use_duration <- 5;
+gas_can_use_duration <- 2;
+upgrade_pack_use_duration <- 2;
+survivor_revive_duration <- 5;
+
+//Chainsaw
+chainsaw_damage <- 100;
+chainsaw_attack_distance <- 50;
+
+//Grenade Launcher
+grenadelauncher_radius_stumble <- 250;
+grenadelauncher_radius_kill <- 180;
+grenadelauncher_damage <- 400;
+
+//Player Cards
+::p1Cards <- {};
+::p2Cards <- {};
+::p3Cards <- {};
+::p4Cards <- {};
+
+if (survivorSet == 1)
+{
+	p1Cards["Bill"] <- 1;
+	p2Cards["Zoey"] <- 1;
+	p3Cards["Louis"] <- 1;
+	p4Cards["Francis"] <- 1;
+}
+else
+{
+	p1Cards["Nick"] <- 1;
+	p2Cards["Rochelle"] <- 1;
+	p3Cards["Coach"] <- 1;
+	p4Cards["Ellis"] <- 1;
+}
+
+cardPickingAllowed <- [false, false, false, false];
+cardsPerCategory <- 2;
+reflexCardsPick <- array(cardsPerCategory);
+brawnCardsPick <- array(cardsPerCategory);
+disciplineCardsPick <- array(cardsPerCategory);
+fortuneCardsPick <- array(cardsPerCategory);
+pickableCards <- array(cardsPerCategory * 4);
+addictPlaySound <- false;
+ConfidentKillerCounter <- 0;
+MethHeadCounter <- [0, 0, 0, 0];
+cardHudTimeout <- 0;
+::AmpedUpCooldown <- 0;
+
+//Specials
+bChargerSpawned <- false;
+
+//Stocks
+firstLeftCheckpoint <- false;
+survivorHealthBuffer <- [0, 0, 0, 0];
+
+///////////////////////////////////////////////
+//                  CONVARS                  //
+///////////////////////////////////////////////
+Convars.SetValue("z_versus_hunter_limit", 0);
+Convars.SetValue("z_versus_spitter_limit", 0);
+Convars.SetValue("z_ghost_delay_minspawn", 20);
+
+///////////////////////////////////////////////
+//              DIRECTOR OPTIONS             //
+///////////////////////////////////////////////
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	cm_AggressiveSpecials = 0
+	
+	cm_DominatorLimit = 4
+	cm_MaxSpecials = 13 //For sleepers, was 4 previously. Game limits max players on server to 18
+	cm_TankLimit = 1
+	cm_WitchLimit = -1
+	cm_CommonLimit = 30
+	cm_ProhibitBosses = true
+
+	MobSpawnMinTime = 9999
+	MobSpawnMaxTime = 9999
+
+	SpecialInitialSpawnDelayMax = 45
+	SpecialInitialSpawnDelayMin = 30
+	SpecialRespawnInterval = 25
+	BoomerLimit = 2
+	ChargerLimit = 1
+	HunterLimit = 0
+	JockeyLimit = 2
+	SmokerLimit = 2
+	SpitterLimit = 0
+	BileMobSize = 0
+
+	TankHitDamageModifierCoop = 1
+	EscapeSpawnTanks = false
+	SurvivorMaxIncapacitatedCount = 2
+}
+
+///////////////////////////////////////////////
+//             DIFFICULTY OPTIONS            //
+///////////////////////////////////////////////
+switch(difficulty)
+{
+	//Easy
+	case 0:
+		Convars.SetValue("z_jockey_health", 361);
+		Convars.SetValue("z_gas_health", 297);
+		Convars.SetValue("z_exploding_health", 595);
+		Convars.SetValue("z_witch_health", 850);
+		DirectorOptions.SurvivorMaxIncapacitatedCount = 3;
+	break;
+
+	//Normal
+	case 1:
+		Convars.SetValue("z_jockey_health", 361);
+		Convars.SetValue("z_gas_health", 297);
+		Convars.SetValue("z_exploding_health", 595);
+		Convars.SetValue("z_witch_health", 850);
+		DirectorOptions.SurvivorMaxIncapacitatedCount = 2;
+	break;
+
+	//Advanced
+	case 2:
+		Convars.SetValue("z_jockey_health", 425);
+		Convars.SetValue("z_gas_health", 350);
+		Convars.SetValue("z_exploding_health", 700);
+		Convars.SetValue("z_witch_health", 1000);
+		DirectorOptions.SurvivorMaxIncapacitatedCount = 2;
+	break;
+
+	//Expert
+	case 3:
+		Convars.SetValue("z_jockey_health", 425);
+		Convars.SetValue("z_gas_health", 350);
+		Convars.SetValue("z_exploding_health", 700);
+		Convars.SetValue("z_witch_health", 1000);
+		DirectorOptions.SurvivorMaxIncapacitatedCount = 1;
+		DirectorOptions.TankHitDamageModifierCoop = 0.48;
+	break;
+}
+
+///////////////////////////////////////////////
+//              GAMEMODE OPTIONS             //
+///////////////////////////////////////////////
+if (swarmMode == "hardcore" || swarmMode == "survival" || swarmMode == "vs" || swarmMode == "survival_vs")
+{
+	DirectorOptions.cm_TankLimit = 2
+}
+
+///////////////////////////////////////////////
+//             SETTINGS / OPTIONS            //
+///////////////////////////////////////////////
+swarmTickInterval <- 1;				// In seconds
+swarmDamagePerTick <- 2;
+
+tankJumpVelocity <- 500;
+tankJumpExtraHeight <- 450;			// Max extra height from aiming up
+
+randomPct <- (RandomInt(1,100))
+spawnBoss <- (RandomFloat(0.1,0.9))
+spawnBreaker <- (RandomFloat(0.1,0.9))
+spawnOgre <- (RandomFloat(0.1,0.9))
+
+breakerSpawned <- false;
+ogreSpawned <- false;
+bossSpawned <- false;
+bossOgreEnable <- false;
+bossBreakerEnable <- false;
+
+// INFECTED //
+boomerExplosionRange <- 250;
+boomerExplosionDamage <- 45;		// Max damage
+boomerExplosionKnockback <- 275;	// Max knockback
+boomerExplodeTime <- 3;				// In seconds
+exploderRunSpeed <- 320;			// Run speed while using explosion ability
+
+tallboyPunchKnockback <- 350;		// Max knockback
+tallboyRunSpeed <- 210;
+
+// COMMON //
+acidCommonsMax <- 4;
+acidCommonSpawnAmount <- 4;			// Size of group to spawn
+acidCommonSpawnRate <- 30;			// How often a group will be spawned in seconds
+
+fireCommonsMax <- 7;
+fireCommonSpawnAmount <- 4;			// Size of group to spawn
+fireCommonSpawnRate <- 30;			// How often a group will be spawned in seconds
+fireCommonDamage <- 2;				// Damage per tick from burning
+fireCommonRange <- 40;				// Size of fire damage hitbox
+
+explodingCommonsMax <- 7;
+explodingCommonSpawnAmount <- 4;	// Size of group to spawn
+explodingCommonSpawnRate <- 30;		// How often a group will be spawned in seconds
+::explodingCommonDamage <- 8;			// Max damage from explosion
+::explodingCommonRange <- 200;		// Explosion range
+::explodingCommonKnockback <- 275;	// Explosion force
+
+// UNCOMMON //
+uncommonMax <- 7;
+uncommonSpawnAmount <- 4;			// Size of group to spawn
+uncommonSpawnRate <- 30;			// How often a group will be spawned in seconds
+
+uncommonJimmyMax <- 3;
+uncommonJimmySpawnAmount <- 3;			// Size of group to spawn
+uncommonJimmySpawnRate <- 30;			// How often a group will be spawned in seconds
+
+// HAZARDS //
+hazardDifficultyScale <- (difficulty + 1) / 2;	// Number of hazards to be scaled with difficulty (Easy (0): 0.5x, Normal (1): 1x, Advanced (2): 1.5x, Expert (3): 2x)
+alarmDoorCountMin <- 2;				// Min number of alarm doors to spawn per map
+alarmDoorCountMax <- 2;				// Max number of alarm doors to spawn per map
+crowGroupCountMin <- 4;				// Mix number of crow groups to spawn
+crowGroupCountMax <- 4;				// Max number of crow groups to spawn
+sleeperCountMin <- 4;				// Mix number of sleepers to spawn
+sleeperCountMax <- 4;				// Max number of sleepers to spawn
+explosiveCarHealth <- 1000;			// HP of explosive cars
+spawnSnitch <- (RandomFloat(0.1,0.9))
+snitchSpawned <- false;
+
+// HEALING //
+medkitHealAmount <- 50;				// HP healed by first aid kits
+pillsHealAmount <- 50;				// HP healed by pain pills
+adrenalineHealAmount <- 25;			// HP healed by adrenaline
+
+// PINGING //
+pingRange <- 2000					// Max range for pinging an object
+pingDuration <- 8					// How many seconds do objects stay pinged

--- a/scripts/vscripts/swarm/swarm_hazards.nut
+++ b/scripts/vscripts/swarm/swarm_hazards.nut
@@ -176,7 +176,7 @@ function InitCrows()
 	{
 		crowOrigin = HazardGetRandomNavArea(hazardNavArray);
 		crowCount = 0;
-		crowGroupName = "__crow_group" + crowsGroupsSpawned;
+		crowGroupName = "__crow_group_" + crowsGroupsSpawned;
 
 		local crowTrigger = SpawnEntityFromTable("trigger_once",
 		{
@@ -218,7 +218,7 @@ function InitCrows()
 
 function SpawnCrows(groupID, crowID, crowOrigin)
 {
-	local crowName = "__crow_group" + groupID + "_" + crowID;
+	local crowName = "__crow_group_" + groupID + "_" + crowID;
 	local randomSpreadX = RandomInt(-32, 32);
 	local randomSpreadY = RandomInt(-32, 32);
 
@@ -237,19 +237,19 @@ function SpawnCrows(groupID, crowID, crowOrigin)
 	});
 
 	crow.SetModelScale(0.5, 0);
-	EntFire(crowName, "SetParent", "__crow_group" + groupID + "_move");
+	EntFire(crowName, "SetParent", "__crow_group_" + groupID + "_move");
 	EntFire(crowName, "AddOutput", "OnTakeDamage !self:RunScriptCode:CrowFlyAway(" + crowsGroupsSpawned + "):0:-1");
 }
 
 function CrowFlyAway(groupID)
 {
-	local crowGroupName = "__crow_group" + groupID;
+	local crowGroupName = "__crow_group_" + groupID;
 
 	// Animate crows flying
 	local i = 0;
 	while (i < 8)
 	{
-		local crowName = "__crow_group" + groupID + "_" + i;
+		local crowName = "__crow_group_" + groupID + "_" + i;
 		//local crowEnt = Entities.FindByName(null, crowName);
 		EntFire(crowName, "DisableCollision");
 		EntFire(crowName, "SetDefaultAnimation", "Pounce");
@@ -259,7 +259,7 @@ function CrowFlyAway(groupID)
 	}
 
 	// Get move object
-	local moveName = "__crow_group" + groupID + "_move";
+	local moveName = "__crow_group_" + groupID + "_move";
 	local moveEnt = Entities.FindByName(null, moveName);
 
 	// Fire events

--- a/scripts/vscripts/swarm/swarm_hazards.nut
+++ b/scripts/vscripts/swarm/swarm_hazards.nut
@@ -36,15 +36,11 @@ function InitAlarmDoors()
 {
 	if (!IsModelPrecached("models/props_doors/emergency_exit_sign.mdl"))
 		PrecacheModel("models/props_doors/emergency_exit_sign.mdl");
-	if (!IsSoundPrecached("vehicles\\car_alarm\\car_alarm.wav"))
-		PrecacheSound("vehicles\\car_alarm\\car_alarm.wav");
 
 	local remainingDoors = null;
 	local door = null;
 	local doorList = array(1, null);
 	doorList.clear();
-
-	//CreateInfectedFilter();
 
 	while ((door = Entities.FindByClassname(door, "prop_door_rotating")) != null)
 	{
@@ -74,7 +70,7 @@ function InitAlarmDoors()
 function CreateAlarmDoor(door)
 {
 	local doorIndex = door.GetEntityIndex();
-	local doorName = "__alarm_door_inst_" + doorIndex;
+	local doorName = "__alarm_door" + doorIndex;
 	DoEntFire("!self", "AddOutput", "targetname " + doorName, 0, door, door);
 
 	local doorX = door.GetOrigin().x;
@@ -138,7 +134,7 @@ function CreateAlarmDoor(door)
 
 function AlarmDoorActivate(doorIndex)
 {
-	local doorEnt = Entities.FindByName(null, "__alarm_door_inst_" + doorIndex);
+	local doorEnt = Entities.FindByName(null, "__alarm_door" + doorIndex);
 	EmitSoundOn("Car.Alarm", doorEnt);
 	ZSpawnMob();
 }
@@ -146,7 +142,7 @@ function AlarmDoorActivate(doorIndex)
 
 function AlarmDoorStopSound(doorIndex)
 {
-	local doorEnt = Entities.FindByName(null, "__alarm_door_inst_" + doorIndex);
+	local doorEnt = Entities.FindByName(null, "__alarm_door" + doorIndex);
 	StopSoundOn("Car.Alarm", doorEnt)
 }
 ::AlarmDoorStopSound <- AlarmDoorStopSound;
@@ -157,13 +153,11 @@ function AlarmDoorStopSound(doorIndex)
 ///////////////////////////////////////////////
 crowsGroupsSpawned <- 0;
 
-if (!IsModelPrecached("models/swarm/jockey_crow.mdl"))
-	PrecacheModel("models/swarm/jockey_crow.mdl");
-//if (!IsSoundPrecached("animation\\crow_flock_farm_05.wav"))
-//	PrecacheSound("animation\\crow_flock_farm_05.wav");
-
 function InitCrows()
 {
+	if (!IsModelPrecached("models/swarm/jockey_crow.mdl"))
+		PrecacheModel("models/swarm/jockey_crow.mdl");
+
 	local crowGroupsToSpawn = null;
 	local crowOrigin = null;
 	local crowCount = 0;
@@ -182,7 +176,7 @@ function InitCrows()
 	{
 		crowOrigin = HazardGetRandomNavArea(hazardNavArray);
 		crowCount = 0;
-		crowGroupName = "__crow_group_inst_" + crowsGroupsSpawned;
+		crowGroupName = "__crow_group" + crowsGroupsSpawned;
 
 		local crowTrigger = SpawnEntityFromTable("trigger_once",
 		{
@@ -224,7 +218,7 @@ function InitCrows()
 
 function SpawnCrows(groupID, crowID, crowOrigin)
 {
-	local crowName = "__crow_group_inst_" + groupID + "_" + crowID;
+	local crowName = "__crow_group" + groupID + "_" + crowID;
 	local randomSpreadX = RandomInt(-32, 32);
 	local randomSpreadY = RandomInt(-32, 32);
 
@@ -243,19 +237,19 @@ function SpawnCrows(groupID, crowID, crowOrigin)
 	});
 
 	crow.SetModelScale(0.5, 0);
-	EntFire(crowName, "SetParent", "__crow_group_inst_" + groupID + "_move");
+	EntFire(crowName, "SetParent", "__crow_group" + groupID + "_move");
 	EntFire(crowName, "AddOutput", "OnTakeDamage !self:RunScriptCode:CrowFlyAway(" + crowsGroupsSpawned + "):0:-1");
 }
 
 function CrowFlyAway(groupID)
 {
-	local crowGroupName = "__crow_group_inst_" + groupID;
+	local crowGroupName = "__crow_group" + groupID;
 
 	// Animate crows flying
 	local i = 0;
 	while (i < 8)
 	{
-		local crowName = "__crow_group_inst_" + groupID + "_" + i;
+		local crowName = "__crow_group" + groupID + "_" + i;
 		//local crowEnt = Entities.FindByName(null, crowName);
 		EntFire(crowName, "DisableCollision");
 		EntFire(crowName, "SetDefaultAnimation", "Pounce");
@@ -265,7 +259,7 @@ function CrowFlyAway(groupID)
 	}
 
 	// Get move object
-	local moveName = "__crow_group_inst_" + groupID + "_move";
+	local moveName = "__crow_group" + groupID + "_move";
 	local moveEnt = Entities.FindByName(null, moveName);
 
 	// Fire events

--- a/scripts/vscripts/swarm/swarm_ping.nut
+++ b/scripts/vscripts/swarm/swarm_ping.nut
@@ -11,7 +11,7 @@ function TraceEye(player)
 	local traceStart = eyePosition;
 	local traceEnd = eyePosition + (eyeAngles.Forward() * pingRange);
 
-	traceTable <-
+	local traceTable =
 	{
 		start = eyePosition
 		end = traceEnd
@@ -94,7 +94,7 @@ function PingEntity(entity, player, tracepos)
 	else if (canGlow == "crows")
 	{
 		local nameArray = split(entityName, "_");
-		local crowGroupName = "__" + nameArray[0] + "_" + nameArray[1] + "_" + nameArray[2] + "_" + nameArray[3] + "*";
+		local crowGroupName = "__" + nameArray[0] + "_" + nameArray[1] + nameArray[2] + "*";
 
 		// Apply ping glow
 		EntFire(crowGroupName, "StartGlowing", "", 0);
@@ -181,7 +181,7 @@ function GetEntityType(entity)
 			return "Snitcher";
 			break;
 		case "prop_door_rotating":
-			if (targetname.find("__alarm_door_inst_") != null)
+			if (targetname.find("__alarm_door") != null)
 			{
 				return "Alarm Door";
 			}

--- a/scripts/vscripts/swarm/swarm_ping.nut
+++ b/scripts/vscripts/swarm/swarm_ping.nut
@@ -94,7 +94,7 @@ function PingEntity(entity, player, tracepos)
 	else if (canGlow == "crows")
 	{
 		local nameArray = split(entityName, "_");
-		local crowGroupName = "__" + nameArray[0] + "_" + nameArray[1] + nameArray[2] + "*";
+		local crowGroupName = "__" + nameArray[0] + "_" + nameArray[1] + "_" + nameArray[2] + "*";
 
 		// Apply ping glow
 		EntFire(crowGroupName, "StartGlowing", "", 0);

--- a/scripts/vscripts/swarm/swarm_playercards_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_playercards_stocks.nut
@@ -49,6 +49,7 @@ brawnCards <-
 	//"Overcrowded",
 	"LastLegs",
 	"BuckshotBruiser",
+	"Lumberjack",
 ];
 
 disciplineCards <-
@@ -74,7 +75,8 @@ disciplineCards <-
 	"ReloadDrills",
 	//"MagCoupler",
 	"Arsonist",
-	"NeedsOfTheMany"
+	"NeedsOfTheMany",
+	"Cannoneer",
 ];
 
 fortuneCards <-
@@ -160,9 +162,9 @@ function AddictGetValue(player)
 	{
 		return 0.05;
 	}
-	else if (healthBuffer >= 10)
+	else if (healthBuffer >= 5)
 	{
-		return -0.10;
+		return -0.05;
 	}
 	else if (healthBuffer > 0)
 	{
@@ -539,6 +541,12 @@ function GetPlayerCardName(cardID, type = "name")
 			case "NeedsOfTheMany":
 				return "Needs Of The Many";
 				break;
+			case "Lumberjack":
+				return "Lumberjack";
+				break;
+			case "Cannoneer":
+				return "Cannoneer"
+				break;
 			default:
 				return cardID;
 				break;
@@ -796,6 +804,12 @@ function GetPlayerCardName(cardID, type = "name")
 				break;
 			case "NeedsOfTheMany":
 				return "+1 Team Life, -10 HP";
+				break;
+			case "Lumberjack":
+				return "+100% Team Chainsaw DMG / Range"
+				break;
+			case "Cannoneer":
+				return "+100% Team Grenade Launcher DMG / Range"
 				break;
 			default:
 				return cardID;

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -1,178 +1,6 @@
 ///////////////////////////////////////////////
-//                  OPTIONS                  //
-///////////////////////////////////////////////
-difficulty <- GetDifficulty();
-survivorSet <- Director.GetSurvivorSet();
-z_speed <- Convars.GetFloat("z_speed");
-
-Convars.SetValue("z_versus_hunter_limit", 0);
-Convars.SetValue("z_versus_spitter_limit", 0);
-Convars.SetValue("z_ghost_delay_minspawn", 20);
-
-// DIRECTOR OPTIONS //
-DirectorOptions <-
-{
-	ActiveChallenge = 1
-
-	cm_AggressiveSpecials = 0
-	
-	cm_DominatorLimit = 4
-	cm_MaxSpecials = 13 //For sleepers, was 4. Game limits max players on server to 18?
-	cm_TankLimit = 1
-	cm_WitchLimit = -1
-	cm_CommonLimit = 30
-	cm_ProhibitBosses = true
-
-	MobSpawnMinTime = 9999
-	MobSpawnMaxTime = 9999
-
-	SpecialInitialSpawnDelayMax = 45
-	SpecialInitialSpawnDelayMin = 30
-	SpecialRespawnInterval = 25
-	BoomerLimit = 2
-	ChargerLimit = 1
-	HunterLimit = 0
-	JockeyLimit = 2
-	SmokerLimit = 2
-	SpitterLimit = 0
-	BileMobSize = 0
-
-	TankHitDamageModifierCoop = 1
-	EscapeSpawnTanks = false
-	SurvivorMaxIncapacitatedCount = 2
-}
-
-// EXPERT OPTIONS //
-// DIFFICULTY OPTIONS //
-if (difficulty == 0)
-{
-	Convars.SetValue("z_jockey_health", 361);
-	Convars.SetValue("z_gas_health", 297);
-	Convars.SetValue("z_exploding_health", 595);
-	Convars.SetValue("z_witch_health", 850);
-	DirectorOptions.SurvivorMaxIncapacitatedCount = 3
-}
-else if (difficulty == 1)
-{
-	Convars.SetValue("z_jockey_health", 361);
-	Convars.SetValue("z_gas_health", 297);
-	Convars.SetValue("z_exploding_health", 595);
-	Convars.SetValue("z_witch_health", 850);
-	DirectorOptions.SurvivorMaxIncapacitatedCount = 2
-}
-else if (difficulty == 2)
-{
-	Convars.SetValue("z_jockey_health", 425);
-	Convars.SetValue("z_gas_health", 350);
-	Convars.SetValue("z_exploding_health", 700);
-	Convars.SetValue("z_witch_health", 1000);
-	DirectorOptions.SurvivorMaxIncapacitatedCount = 2
-}
-else if (difficulty == 3)
-{
-	Convars.SetValue("z_jockey_health", 425);
-	Convars.SetValue("z_gas_health", 350);
-	Convars.SetValue("z_exploding_health", 700);
-	Convars.SetValue("z_witch_health", 1000);
-	DirectorOptions.SurvivorMaxIncapacitatedCount = 1
-	DirectorOptions.TankHitDamageModifierCoop = 0.48
-}
-
-// BOSSES //
-swarmTickInterval <- 1;				// In seconds
-swarmDamagePerTick <- 2;
-
-tankJumpVelocity <- 475;
-tankJumpExtraHeight <- 325;			// Max extra height from aiming up
-
-randomPct <- (RandomInt(1,100))
-spawnBoss <- (RandomFloat(0.1,0.9))
-spawnBreaker <- (RandomFloat(0.1,0.9))
-spawnOgre <- (RandomFloat(0.1,0.9))
-
-breakerSpawned <- false;
-ogreSpawned <- false;
-bossSpawned <- false;
-bossOgreEnable <- false;
-bossBreakerEnable <- false;
-
-// INFECTED //
-boomerExplosionRange <- 250;
-boomerExplosionDamage <- 45;		// Max damage
-boomerExplosionKnockback <- 275;	// Max knockback
-boomerExplodeTime <- 3;				// In seconds
-
-tallboyPunchKnockback <- 350;		// Max knockback
-tallboyRunSpeed <- 210;
-
-// COMMON //
-acidCommonsMax <- 4;
-acidCommonSpawnAmount <- 4;			// Size of group to spawn
-acidCommonSpawnRate <- 30;			// How often a group will be spawned in seconds
-
-fireCommonsMax <- 7;
-fireCommonSpawnAmount <- 4;			// Size of group to spawn
-fireCommonSpawnRate <- 30;			// How often a group will be spawned in seconds
-fireCommonDamage <- 2;				// Damage per tick from burning
-fireCommonRange <- 40;				// Size of fire damage hitbox
-
-explodingCommonsMax <- 7;
-explodingCommonSpawnAmount <- 4;	// Size of group to spawn
-explodingCommonSpawnRate <- 30;		// How often a group will be spawned in seconds
-::explodingCommonDamage <- 8;			// Max damage from explosion
-::explodingCommonRange <- 200;		// Explosion range
-::explodingCommonKnockback <- 275;	// Explosion force
-
-// UNCOMMON //
-uncommonMax <- 7;
-uncommonSpawnAmount <- 4;			// Size of group to spawn
-uncommonSpawnRate <- 30;			// How often a group will be spawned in seconds
-
-uncommonJimmyMax <- 3;
-uncommonJimmySpawnAmount <- 3;			// Size of group to spawn
-uncommonJimmySpawnRate <- 30;			// How often a group will be spawned in seconds
-
-// HAZARDS //
-hazardDifficultyScale <- (difficulty + 1) / 2;	// Number of hazards to be scaled with difficulty (Easy (0): 0.5x, Normal (1): 1x, Advanced (2): 1.5x, Expert (3): 2x)
-
-alarmDoorCountMin <- 2;				// Min number of alarm doors to spawn per map
-alarmDoorCountMax <- 2;				// Max number of alarm doors to spawn per map
-
-crowGroupCountMin <- 4;				// Mix number of crow groups to spawn
-crowGroupCountMax <- 4;				// Max number of crow groups to spawn
-
-sleeperCountMin <- 4;				// Mix number of sleepers to spawn
-sleeperCountMax <- 4;				// Max number of sleepers to spawn
-
-explosiveCarHealth <- 1000;			// HP of explosive cars
-
-spawnSnitch <- (RandomFloat(0.1,0.9))
-
-snitchSpawned <- false;
-
-// HEALING //
-medkitHealAmount <- 50;				// HP healed by first aid kits
-pillsHealAmount <- 50;				// HP healed by pain pills
-adrenalineHealAmount <- 25;			// HP healed by adrenaline
-
-// PINGING //
-pingRange <- 2000					// Max range for pinging an object
-pingDuration <- 8					// How many seconds do objects stay pinged
-
-
-//MODE SPECIFIC CHANGES
-if (swarmMode == "hardcore" || swarmMode == "survival" || swarmMode == "vs")
-{
-	DirectorOptions.cm_TankLimit = 2
-}
-
-
-///////////////////////////////////////////////
 //               SHARED EVENTS               //
 ///////////////////////////////////////////////
-firstLeftCheckpoint <- false;
-cardHudTimeout <- 0;
-
 function InterceptChat(message, speaker)
 {
 	// Remove player name from message
@@ -431,6 +259,7 @@ function AllowTakeDamage(damageTable)
 				if (RandomInt(1, 100) <= critChance)
 				{
 					LuckyShotRoll = 1;
+					CriticalHit(attacker, damageTable.Location);
 				}
 
 				//EyeOfTheSwarm
@@ -595,16 +424,45 @@ function AllowTakeDamage(damageTable)
 	return true;
 }
 
-/*pipeDuration <- Convars.GetFloat("pipe_bomb_timer_duration");
-function OnGameEvent_weapon_fire(params)
+function CriticalHit(player, location)
 {
-	ThrowPipeBomb(params);
-}*/
+	local id = location.Length();
 
-function OnGameEvent_player_spawn(params)
+	local target = SpawnEntityFromTable("info_particle_target",
+	{
+		targetname = "__critical_particle_target" + id,
+		origin = Vector(location.x, location.y, location.z + 16)
+	});
+	local particle = SpawnEntityFromTable("info_particle_system",
+	{
+		targetname = "__critical_particle" + id,
+		origin = Vector(location.x, location.y, location.z - 16),
+		cpoint1 = "__critical_particle_target" + id,
+		effect_name = "electrical_arc_01",
+		start_active = 1
+	});
+
+	local random = RandomInt(1, 3);
+	if (random == 1)
+	{
+		//EmitSoundOnClient("ambient.electrical_zap_1", player);
+		EmitAmbientSoundOn("ambient.electrical_zap_1", 0.75, RandomInt(95, 105), RandomInt(90, 110), target);
+	}
+	else if (random == 2)
+	{
+		//EmitSoundOnClient("ambient.electrical_zap_2", player);
+		EmitAmbientSoundOn("ambient.electrical_zap_2", 0.75, RandomInt(95, 105), RandomInt(90, 110), target);
+	}
+	else
+	{
+		//EmitSoundOnClient("ambient.electrical_zap_3", player);
+		EmitAmbientSoundOn("ambient.electrical_zap_2", 0.75, RandomInt(95, 105), RandomInt(90, 110), target);
+	}
+}
+
+function PlayerSpawn(params)
 {
 	local player = GetPlayerFromUserID(params["userid"]);
-
 	if (!player)
 	{
 		return;
@@ -620,12 +478,14 @@ function OnGameEvent_player_spawn(params)
 	else
 	{
 		MutationSpawn(player);
+		if (corruptionEnvironmental == "environmentSwarmStream" && RandomInt(0, 2) == 0)
+		{
+			CorruptionCard_SwarmStreamGlow(player);
+		}
 	}
 }
 
-ConfidentKillerCounter <- 0;
-MethHeadCounter <- [0, 0, 0, 0];
-function OnGameEvent_player_death(params)
+function PlayerDeath(params)
 {
 	local player = null;
 	local isSurvivorDeath = false;
@@ -762,15 +622,8 @@ function OnGameEvent_player_death(params)
 	}
 }
 
-function OnGameEvent_player_incapacitated_start(params)
-{
-	//AdrenalineRush
-	//InspiringSacrifice
-	ApplyAdrenalineRush();
-	ApplyInspiringSacrifice();
-}
 
-function OnGameEvent_round_start(params)
+function RoundStart(params)
 {
 	CreateCardHud();
 
@@ -791,12 +644,7 @@ function OnGameEvent_round_start(params)
 	}
 }
 
-function OnGameEvent_player_activate(params)
-{
-	CorruptionDropItems();
-}
-
-function OnGameEvent_player_left_safe_area(params)
+function PlayerLeftSafeArea(params)
 {
 	if (firstLeftCheckpoint == false)
 	{
@@ -809,104 +657,115 @@ function OnGameEvent_player_left_safe_area(params)
 				// Print the number of continues left.
 				ClientPrint(null, 3, "\x04" + "Continues: " + "\x01"+ (3 - Director.GetMissionWipes()));
 			}
-	switch(corruptionHordes)
-	{
-		case "hordeHunted":
-			HuntedEnabled = true;
-			HuntedTimer = Time() + 180 + 30;
-			break;
-		case "hordeOnslaught":
-			OnslaughtEnabled = true;
-			OnslaughtTimer = Time() + 90 + 30;
-			break;
-		case "hordeTallboy":
-			TallboyHordeEnabled = true;
-			SpecialHordeTimer = Time() + 90 + 30;
-			break;
-		case "hordeCrusher":
-			CrusherHordeEnabled = true;
-			SpecialHordeTimer = Time() + 90 + 30;
-			break;
-		case "hordeBruiser":
-			BruiserHordeEnabled = true;
-			SpecialHordeTimer = Time() + 90 + 30;
-			break;
-		case "hordeStalker":
-			StalkerHordeEnabled = true;
-			SpecialHordeTimer = Time() + 90 + 30;
-			break;
-		case "hordeHocker":
-			HockerHordeEnabled = true;
-			SpecialHordeTimer = Time() + 90 + 30;
-			break;
-		case "hordeExploder":
-			ExploderHordeEnabled = true;
-			SpecialHordeTimer = Time() + 90 + 30;
-			break;
-		case "hordeRetch":
-			RetchHordeEnabled = true;
-			SpecialHordeTimer = Time() + 90 + 30;
-			break;
-	}
+
+			switch(corruptionHordes)
+			{
+				case "hordeHunted":
+					HuntedEnabled = true;
+					HuntedTimer = Time() + 180 + 30;
+					break;
+				case "hordeOnslaught":
+					OnslaughtEnabled = true;
+					OnslaughtTimer = Time() + 90 + 30;
+					break;
+				case "hordeTallboy":
+					TallboyHordeEnabled = true;
+					SpecialHordeTimer = Time() + 90 + 30;
+					break;
+				case "hordeCrusher":
+					CrusherHordeEnabled = true;
+					SpecialHordeTimer = Time() + 90 + 30;
+					break;
+				case "hordeBruiser":
+					BruiserHordeEnabled = true;
+					SpecialHordeTimer = Time() + 90 + 30;
+					break;
+				case "hordeStalker":
+					StalkerHordeEnabled = true;
+					SpecialHordeTimer = Time() + 90 + 30;
+					break;
+				case "hordeHocker":
+					HockerHordeEnabled = true;
+					SpecialHordeTimer = Time() + 90 + 30;
+					break;
+				case "hordeExploder":
+					ExploderHordeEnabled = true;
+					SpecialHordeTimer = Time() + 90 + 30;
+					break;
+				case "hordeRetch":
+					RetchHordeEnabled = true;
+					SpecialHordeTimer = Time() + 90 + 30;
+					break;
+			}
 
 			firstLeftCheckpoint = true;
 			cardHudTimeout = 0;
 
-			InitAlarmDoors();
-			InitCrows();
 			ModifyHittables();
-			InitSleepers();
+			ApplyEnvironmentalCard();
+
+			if (corruptionHazards == "hazardLockdown")
+			{
+				InitAlarmDoors();
+			}
+			else if (corruptionHazards == "hazardBirds")
+			{
+				InitCrows();
+			}
+			else if (corruptionHazards == "hazardSleepers")
+			{
+				InitSleepers();
+			}
 		}
 	}
 }
 
-function OnGameEvent_player_hurt(params)
+function PlayerHurt(params)
 {
 	//Add FX when being hit by script spawned spit
 	local player = GetPlayerFromUserID(params.userid);
-	local attackerID = GetPlayerFromUserID(params.attacker);
 
-	if (player == attackerID || attackerID == null)
+	if (player.IsValid())
 	{
-		return;
-	}
+		//Survivor was hurt
+		if (player.GetZombieType() == 9)
+		{
+			if (params.type == 265216)
+			{
+				//Spit damage
+				ScreenFade(player, 0, 200, 0, 50, 0.5, 0, 1);
+				EmitSoundOnClient("PlayerZombie.AttackHit", player);
+			}
+			else if (params.type == 8)
+			{
+				//Fire damage
+				ScreenFade(player, 255, 70, 0, 50, 0.5, 0, 1);
+				EmitSoundOnClient("General.BurningObject", player);
+			}
 
-	//Survivor was hurt
-	if (player.GetZombieType() == 9)
-	{
-		if (params.type == 265216)
-		{
-			//Spit damage
-			ScreenFade(player, 0, 200, 0, 50, 0.5, 0, 1);
-			EmitSoundOnClient("PlayerZombie.AttackHit", player);
-		}
-		else if (params.type == 8)
-		{
-			ScreenFade(player, 255, 70, 0, 50, 0.5, 0, 1);
-			EmitSoundOnClient("General.BurningObject", player);
-		}
-
-		if (params.weapon == "charger_claw")
-		{
 			//Charger scratch
-			local attacker = GetPlayerFromUserID(params.attacker);
-			TallboyKnockback(attacker, player);
+			if (params.weapon == "charger_claw" && corruptionTallboy != "Crusher")
+			{
+				local attacker = GetPlayerFromUserID(params.attacker);
+				if (attacker.IsValid() && player != attacker)
+				{
+					TallboyKnockback(attacker, player);
+				}
+			}
 		}
 	}
 }
 
-//Store temp health at time of heal
-survivorHealthBuffer <- [0, 0, 0, 0];
 
 //Use heal begin because heal end is bugged, so restored temp health may not be accurate
-function OnGameEvent_heal_begin(params)
+function HealBegin(params)
 {
 	local player = GetPlayerFromUserID(params.subject);
 	local currentTempHealth = player.GetHealthBuffer();
-	survivorHealthBuffer[GetSurvivorID(player)] = currentTempHealth;
+	survivorHealthBuffer[GetSurvivorID(player)] = currentTempHealth; //Store temp health at time of heal
 }
 
-function OnGameEvent_heal_success(params)
+function HealSuccess(params)
 {
 	local healer = GetPlayerFromUserID(params.userid);
 	local player = GetPlayerFromUserID(params.subject);
@@ -930,7 +789,7 @@ function OnGameEvent_heal_success(params)
 	Heal_GroupTherapy(player, healAmount, false);
 }
 
-function OnGameEvent_pills_used(params)
+function PillsUsed(params)
 {
 	local player = GetPlayerFromUserID(params.subject);
 	local maxHealth = player.GetMaxHealth();
@@ -955,7 +814,7 @@ function OnGameEvent_pills_used(params)
 	Heal_GroupTherapy(player, healAmount, true);
 }
 
-function OnGameEvent_adrenaline_used(params)
+function AdrenalineUsed(params)
 {
 	local player = GetPlayerFromUserID(params.subject);
 	local maxHealth = player.GetMaxHealth();
@@ -1069,7 +928,7 @@ function Heal_GroupTherapy(healTarget, healAmount, isTempHealth)
 	}
 }
 
-function OnGameEvent_revive_success(params)
+function ReviveSuccess(params)
 {
 	local ledgeHang = params.ledge_hang;
 	if (ledgeHang == 0)
@@ -1098,69 +957,57 @@ function OnGameEvent_revive_success(params)
 	}
 }
 
-function OnGameEvent_triggered_car_alarm(params)
+function Heal_AmpedUp()
 {
 	local AmpedUp = TeamHasCard("AmpedUp");
 	if (AmpedUp > 0)
 	{
-		Heal_AmpedUp(AmpedUp);
-	}
-}
-
-::AmpedUpCooldown <- 0;
-function Heal_AmpedUp(AmpedUp)
-{
-	if (AmpedUpCooldown <= 0)
-	{
-		local player = null;
-		while ((player = Entities.FindByClassname(player, "player")) != null)
+		if (AmpedUpCooldown <= 0)
 		{
-			if (player.IsSurvivor())
+			local player = null;
+			while ((player = Entities.FindByClassname(player, "player")) != null)
 			{
-				local currentTempHealth = player.GetHealthBuffer();
-				local currentHealth = player.GetHealth();
-				local maxHealth = player.GetMaxHealth();
-
-				local healAmount = 20 * AmpedUp;
-
-				if (healAmount + currentHealth > maxHealth)
+				if (player.IsSurvivor())
 				{
-					player.SetHealth(maxHealth);
-				}
-				else
-				{
-					player.SetHealth(healAmount + currentHealth);
-				}
+					local currentTempHealth = player.GetHealthBuffer();
+					local currentHealth = player.GetHealth();
+					local maxHealth = player.GetMaxHealth();
 
-				local currentHealth = player.GetHealth();
-				if (currentHealth + currentTempHealth > maxHealth)
-				{
-					player.SetHealthBuffer(maxHealth - currentHealth)
+					local healAmount = 20 * AmpedUp;
+
+					if (healAmount + currentHealth > maxHealth)
+					{
+						player.SetHealth(maxHealth);
+					}
+					else
+					{
+						player.SetHealth(healAmount + currentHealth);
+					}
+
+					local currentHealth = player.GetHealth();
+					if (currentHealth + currentTempHealth > maxHealth)
+					{
+						player.SetHealthBuffer(maxHealth - currentHealth)
+					}
 				}
 			}
-		}
 
-		AmpedUpCooldown = 5;
+			AmpedUpCooldown = 5;
+		}
 	}
 }
 ::Heal_AmpedUp <- Heal_AmpedUp;
 
-function OnGameEvent_player_shoved(params)
+function CappedAlert()
 {
-	//Kill sleeper on shove
-	local hunter = GetPlayerFromUserID(params.userid);
-	local survivor = GetPlayerFromUserID(params.attacker);
-	if (hunter.GetZombieType() == 3)
+	local player = null;
+	while ((player = Entities.FindByClassname(player, "player")) != null)
 	{
-		hunter.TakeDamage(250, 2097152, survivor);
+		if (player.IsSurvivor())
+		{
+			EmitSoundOnClient("Instructor.ImportantLessonStart", player);
+		}
 	}
-}
-
-function OnGameEvent_item_pickup(params)
-{
-	TallboySpawn(params);
-	SurvivorPickupItem(params);
-	InitOptics(params);
 }
 
 ///////////////////////////////////////////////
@@ -1376,6 +1223,9 @@ function Update()
 	{
 		AmpedUpCooldown--;
 	}
+
+	//Remove critical particles
+	EntFire("__critical_particle*", "Kill");
 }
 
 function SpawnMob(count = 1, zType = 10)
@@ -1402,11 +1252,7 @@ function SpawnMob(count = 1, zType = 10)
 		i++;
 	}
 
-	local AmpedUp = TeamHasCard("AmpedUp");
-	if (AmpedUp > 0)
-	{
-		Heal_AmpedUp(AmpedUp);
-	}
+	Heal_AmpedUp();
 }
 ::ZSpawnMob <- SpawnMob;
 

--- a/scripts/vscripts/swarm_hardcore.nut
+++ b/scripts/vscripts/swarm_hardcore.nut
@@ -5,11 +5,14 @@ swarmMode <- "hardcore";
 ///////////////////////////////////////////////
 //              INCLUDE SCRIPTS              //
 ///////////////////////////////////////////////
+IncludeScript("swarm/swarm_globals");
 IncludeScript("swarm/swarm_stocks");
+IncludeScript("swarm/swarm_game_events");
 IncludeScript("swarm/swarm_corruption");
 IncludeScript("swarm/swarm_breaker");
 IncludeScript("swarm/swarm_specials");
 IncludeScript("swarm/swarm_commons");
 IncludeScript("swarm/swarm_hazards");
 IncludeScript("swarm/swarm_ping");
+IncludeScript("swarm/swarm_playercards_stocks");
 IncludeScript("swarm/swarm_playercards");

--- a/scripts/vscripts/swarm_survival.nut
+++ b/scripts/vscripts/swarm_survival.nut
@@ -5,11 +5,14 @@ swarmMode <- "survival";
 ///////////////////////////////////////////////
 //              INCLUDE SCRIPTS              //
 ///////////////////////////////////////////////
+IncludeScript("swarm/swarm_globals");
 IncludeScript("swarm/swarm_stocks");
+IncludeScript("swarm/swarm_game_events");
 IncludeScript("swarm/swarm_corruption");
 IncludeScript("swarm/swarm_breaker");
 IncludeScript("swarm/swarm_specials");
 IncludeScript("swarm/swarm_commons");
 IncludeScript("swarm/swarm_hazards");
 IncludeScript("swarm/swarm_ping");
+IncludeScript("swarm/swarm_playercards_stocks");
 IncludeScript("swarm/swarm_playercards");

--- a/scripts/vscripts/swarm_survival_vs.nut
+++ b/scripts/vscripts/swarm_survival_vs.nut
@@ -1,15 +1,18 @@
 Msg("Activating Swarm\n");
 
-swarmMode <- "survival"
+swarmMode <- "survival_vs"
 
 ///////////////////////////////////////////////
 //              INCLUDE SCRIPTS              //
 ///////////////////////////////////////////////
+IncludeScript("swarm/swarm_globals");
 IncludeScript("swarm/swarm_stocks");
+IncludeScript("swarm/swarm_game_events");
 IncludeScript("swarm/swarm_corruption");
 IncludeScript("swarm/swarm_breaker");
 IncludeScript("swarm/swarm_specials");
 IncludeScript("swarm/swarm_commons");
 IncludeScript("swarm/swarm_hazards");
 IncludeScript("swarm/swarm_ping");
+IncludeScript("swarm/swarm_playercards_stocks");
 IncludeScript("swarm/swarm_playercards");

--- a/scripts/vscripts/swarm_vs.nut
+++ b/scripts/vscripts/swarm_vs.nut
@@ -5,11 +5,14 @@ swarmMode <- "vs";
 ///////////////////////////////////////////////
 //              INCLUDE SCRIPTS              //
 ///////////////////////////////////////////////
+IncludeScript("swarm/swarm_globals");
 IncludeScript("swarm/swarm_stocks");
+IncludeScript("swarm/swarm_game_events");
 IncludeScript("swarm/swarm_corruption");
 IncludeScript("swarm/swarm_breaker");
 IncludeScript("swarm/swarm_specials");
 IncludeScript("swarm/swarm_commons");
 IncludeScript("swarm/swarm_hazards");
 IncludeScript("swarm/swarm_ping");
+IncludeScript("swarm/swarm_playercards_stocks");
 IncludeScript("swarm/swarm_playercards");


### PR DESCRIPTION
Environmental cards are applied when leaving the spawn
Added the Swarm Stream corruption card
Fixed Crushers teleporting players outside the map
Changed Sleeper pounce sound
Adjusted Addict visual effects and negative penalty threshold
Exploder runs faster while detonating
Added FX for critical hits
Moved OnGameEvent functions into their own script and decoupled all functions from the initial OnGameEvent call
Moved global variables/options to their own script and reorganized
Player cards are no longer carried between rounds in versus modes
Fixed spit and fire common damage FX not working
Added Lumberjack player card
Added Cannoneer player card
Added a helpful alert sound that plays whenever a survivor is capped
Increased Breaker jump range
Fixed Breaker sometimes getting stuck after a jump


Surely nothing will be broken in _this_ update.