### PR TITLE
Add barbed wire, ogre stagger, fire on infected extinguish, and other fixes

### DIFF
--- a/modes/swarm.txt
+++ b/modes/swarm.txt
@@ -64,9 +64,9 @@
 		
 		z_tank_damage_slow_max_range 0
 		tank_ground_pound_duration 3
-		tank_burn_duration 150
-		tank_burn_duration_hard 155
-		tank_burn_duration_expert 160
+		tank_burn_duration 30
+		tank_burn_duration_hard 35
+		tank_burn_duration_expert 40
 		tank_swing_physics_prop_force 0
 		vs_tank_damage 18
 		

--- a/modes/swarm_hardcore.txt
+++ b/modes/swarm_hardcore.txt
@@ -64,9 +64,9 @@
 		
 		z_tank_damage_slow_max_range 0
 		tank_ground_pound_duration 3
-		tank_burn_duration 150
-		tank_burn_duration_hard 155
-		tank_burn_duration_expert 160
+		tank_burn_duration 30
+		tank_burn_duration_hard 35
+		tank_burn_duration_expert 40
 		tank_swing_physics_prop_force 0
 		vs_tank_damage 18
 		

--- a/modes/swarm_survival.txt
+++ b/modes/swarm_survival.txt
@@ -64,9 +64,9 @@
 		
 		z_tank_damage_slow_max_range 0
 		tank_ground_pound_duration 3
-		tank_burn_duration 150
-		tank_burn_duration_hard 155
-		tank_burn_duration_expert 160
+		tank_burn_duration 30
+		tank_burn_duration_hard 35
+		tank_burn_duration_expert 40
 		tank_swing_physics_prop_force 0
 		vs_tank_damage 18
 		

--- a/modes/swarm_survival_vs.txt
+++ b/modes/swarm_survival_vs.txt
@@ -65,9 +65,9 @@
 		
 		z_tank_damage_slow_max_range 0
 		tank_ground_pound_duration 3
-		tank_burn_duration 150
-		tank_burn_duration_hard 155
-		tank_burn_duration_expert 160
+		tank_burn_duration 30
+		tank_burn_duration_hard 35
+		tank_burn_duration_expert 40
 		tank_swing_physics_prop_force 0
 		vs_tank_damage 18
 		

--- a/modes/swarm_vs.txt
+++ b/modes/swarm_vs.txt
@@ -66,9 +66,9 @@
 		
 		z_tank_damage_slow_max_range 0
 		tank_ground_pound_duration 3
-		tank_burn_duration 150
-		tank_burn_duration_hard 155
-		tank_burn_duration_expert 160
+		tank_burn_duration 30
+		tank_burn_duration_hard 35
+		tank_burn_duration_expert 40
 		tank_swing_physics_prop_force 0
 		vs_tank_damage 18
 		

--- a/scripts/vscripts/swarm/swarm_game_events.nut
+++ b/scripts/vscripts/swarm/swarm_game_events.nut
@@ -186,34 +186,7 @@ function OnGameEvent_item_pickup(params)
 
 function OnGameEvent_upgrade_pack_used(params)
 {
-		local player = GetPlayerFromUserID(params.userid);
-		local wireX = player.GetOrigin().x;
-		local wireY = player.GetOrigin().y;
-		local wireZ = player.GetOrigin().z;
-		local wireAngleX = player.GetAngles().x;
-		local wireAngleY = player.GetAngles().y;
-		local wireName = "wire";
-		local wire = SpawnEntityFromTable("prop_dynamic",
-		{
-			targetname = wireName,
-			origin = Vector(wireX, wireY, wireZ+18),
-			angles = Vector(wireAngleX, wireAngleY, 0)
-			model = "models/props_street/concertinawire128_rusty.mdl",
-			solid = 0,
-			disableshadows = 1,
-		});
-		local wireTrigger = SpawnEntityFromTable("trigger_hurt",
-		{
-			targetname = wireName + "_trigger",
-			origin = Vector(wireX, wireY, wireZ+18),
-			angles = Vector(wireAngleX, wireAngleY, 0)
-			damagetype = 0,
-			damage = 25,
-			spawnflags = 3,
-			filtername = "__swarm_filter_infected"
-		});
-		// Set up trigger
-		DoEntFire("!self", "AddOutput", "mins -44 -44 0", 0, null, wireTrigger);
-		DoEntFire("!self", "AddOutput", "maxs 44 44 28", 0, null, wireTrigger);
-		DoEntFire("!self", "AddOutput", "solid 2", 0, null, wireTrigger);
+	BarbedWire(params);
+// Need a way to distinguish these
+//	AmmoPack(params);
 }

--- a/scripts/vscripts/swarm/swarm_game_events.nut
+++ b/scripts/vscripts/swarm/swarm_game_events.nut
@@ -183,3 +183,37 @@ function OnGameEvent_item_pickup(params)
 	SurvivorPickupItem(params);
 	InitOptics(params);
 }
+
+function OnGameEvent_upgrade_pack_used(params)
+{
+		local player = GetPlayerFromUserID(params.userid);
+		local wireX = player.GetOrigin().x;
+		local wireY = player.GetOrigin().y;
+		local wireZ = player.GetOrigin().z;
+		local wireAngleX = player.GetAngles().x;
+		local wireAngleY = player.GetAngles().y;
+		local wireName = "wire";
+		local wire = SpawnEntityFromTable("prop_dynamic",
+		{
+			targetname = wireName,
+			origin = Vector(wireX, wireY, wireZ+18),
+			angles = Vector(wireAngleX, wireAngleY, 0)
+			model = "models/props_street/concertinawire128_rusty.mdl",
+			solid = 0,
+			disableshadows = 1,
+		});
+		local wireTrigger = SpawnEntityFromTable("trigger_hurt",
+		{
+			targetname = wireName + "_trigger",
+			origin = Vector(wireX, wireY, wireZ+18),
+			angles = Vector(wireAngleX, wireAngleY, 0)
+			damagetype = 0,
+			damage = 25,
+			spawnflags = 3,
+			filtername = "__swarm_filter_infected"
+		});
+		// Set up trigger
+		DoEntFire("!self", "AddOutput", "mins -44 -44 0", 0, null, wireTrigger);
+		DoEntFire("!self", "AddOutput", "maxs 44 44 28", 0, null, wireTrigger);
+		DoEntFire("!self", "AddOutput", "solid 2", 0, null, wireTrigger);
+}

--- a/scripts/vscripts/swarm/swarm_globals.nut
+++ b/scripts/vscripts/swarm/swarm_globals.nut
@@ -223,6 +223,7 @@ switch(difficulty)
 		Convars.SetValue("z_witch_health", 850);
 		BaseMaxIncaps = 3;
 		MaxTraumaDamage = 0;
+		stagger_dmg = 4000;
 	break;
 
 	//Normal
@@ -233,6 +234,7 @@ switch(difficulty)
 		Convars.SetValue("z_witch_health", 850);
 		BaseMaxIncaps = 2;
 		MaxTraumaDamage = 20;
+		stagger_dmg = 4000;
 	break;
 
 	//Advanced
@@ -243,6 +245,7 @@ switch(difficulty)
 		Convars.SetValue("z_witch_health", 1000);
 		BaseMaxIncaps = 2;
 		MaxTraumaDamage = 30;
+		stagger_dmg = 10000;
 	break;
 
 	//Expert
@@ -253,6 +256,7 @@ switch(difficulty)
 		Convars.SetValue("z_witch_health", 1000);
 		BaseMaxIncaps = 1;
 		MaxTraumaDamage = 40;
+		stagger_dmg = 10000;
 		DirectorOptions.TankHitDamageModifierCoop = 0.48;
 	break;
 }

--- a/scripts/vscripts/swarm/swarm_globals.nut
+++ b/scripts/vscripts/swarm/swarm_globals.nut
@@ -105,7 +105,10 @@ grenadelauncher_radius_kill <- 180;
 grenadelauncher_damage <- 400;
 
 //Infected Fire Timer
-extinguish_time <- 0
+extinguish_time <- 0;
+
+//Ogre Stagger
+stagger_dmg <- null;
 
 //Player Cards
 ::p1Cards <- {};

--- a/scripts/vscripts/swarm/swarm_globals.nut
+++ b/scripts/vscripts/swarm/swarm_globals.nut
@@ -105,7 +105,7 @@ grenadelauncher_radius_kill <- 180;
 grenadelauncher_damage <- 400;
 
 //Infected Fire Timer
-extinguish_time <- 0;
+extinguish_time <- null;
 
 //Ogre Stagger
 stagger_dmg <- null;

--- a/scripts/vscripts/swarm/swarm_globals.nut
+++ b/scripts/vscripts/swarm/swarm_globals.nut
@@ -104,6 +104,9 @@ grenadelauncher_radius_stumble <- 250;
 grenadelauncher_radius_kill <- 180;
 grenadelauncher_damage <- 400;
 
+//Infected Fire Timer
+extinguish_time <- 0
+
 //Player Cards
 ::p1Cards <- {};
 ::p2Cards <- {};

--- a/scripts/vscripts/swarm/swarm_playercards.nut
+++ b/scripts/vscripts/swarm/swarm_playercards.nut
@@ -682,24 +682,6 @@ function SurvivorPickupItem(params)
 	}
 }
 
-/* Is this still needed?
-function OnGameEvent_weapon_drop(params)
-{
-	if ("propid" in params)
-	{
-		local weaponID = params.propid;
-		if (weaponID != null)
-		{
-			local weapon = null;
-			while ((weapon = Entities.FindByName(weapon, "shotgunThinker" + weaponID)) != null)
-			{
-				printl("kill " + weaponID)
-				weapon.Kill();
-			}
-		}
-	}
-}*/
-
 function Update_PlayerCards()
 {
 	//Runs every second

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -819,11 +819,10 @@ function PlayerHurt(params)
 			{
 				if (params.type == 8)
 				{
-					local time = Time();
-					local extinguish_time = Time() + 5;
-					if (time > extinguish_time)
+					if (Time() > extinguish_time + 5)
 					{
 						player.Extinguish()
+						extinguish_time = Time();
 					}
 				}
 			}

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -818,11 +818,11 @@ function PlayerHurt(params)
 			{
 				if (params.type == 8)
 				{
-					if (Time() > extinguish_time + 5)
-					{
+					//if (Time() > extinguish_time + 5)
+					//{
 						player.Extinguish()
 						extinguish_time = Time();
-					}
+					//}
 				}
 			}
 		}
@@ -1473,7 +1473,6 @@ function BarbedWire(params)
 	{
 		targetname = wireName + "_trigger",
 		origin = Vector(wireX, wireY, wireZ),
-		angles = Vector(wireAngleX, wireAngleY, 0)
 		damagetype = 0,
 		damage = 25,
 		spawnflags = 3,
@@ -1483,7 +1482,7 @@ function BarbedWire(params)
 	// Set up trigger
 	DoEntFire("!self", "AddOutput", "mins -44 -44 0", 0, null, wireTrigger);
 	DoEntFire("!self", "AddOutput", "maxs 44 44 28", 0, null, wireTrigger);
-	DoEntFire("!self", "AddOutput", "solid 0", 0, null, wireTrigger);
+	DoEntFire("!self", "AddOutput", "solid 2", 0, null, wireTrigger);
 	// Remove ammo pack model
 	foreach(modelpath in ItemstoRemove_ModelPaths)
 	{
@@ -1493,6 +1492,7 @@ function BarbedWire(params)
 	}
 }
 
+/*
 function AmmoPack(params)
 {
 	local ItemstoRemove_ModelPaths =
@@ -1526,3 +1526,4 @@ function AmmoPack(params)
 			weapon_ent.Kill();
 	}
 }
+*/

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -817,10 +817,10 @@ function PlayerHurt(params)
 		{
 			if ("type" in params)
 			{
-				if (params.type == 8 && player.IsSurvivor() == false)
+				if (params.type == 8)
 				{
 					local time = Time();
-					local extinguish_time = 5;
+					local extinguish_time = Time() + 5;
 					if (time > extinguish_time)
 					{
 						player.Extinguish()

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -804,12 +804,11 @@ function PlayerHurt(params)
 		{
 			if ("type" in params)
 			{
-				local boss_health = player.GetMaxHealth() / 2;
-				if (params.type == 2 && params.health < boss_health)
+				if (params.type == 2 && params.health < stagger_dmg)
 				{
 					//Stagger tank
 					player.Stagger(Vector(-1, -1, -1));
-					boss_health = player.GetHealth() / 4;
+					stagger_dmg = player.GetHealth() / 4;
 				}
 			}
 		}

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -804,8 +804,8 @@ function PlayerHurt(params)
 		{
 			if ("type" in params)
 			{
-				local boss_health = player.GetMaxHealth();
-				if (params.type == 2 && params.dmg_health > boss_health/2)
+				local boss_health = player.GetMaxHealth() / 2;
+				if (params.type == 2 && params.health < boss_health)
 				{
 					//Stagger tank
 					player.Stagger(Vector(0, 0, 0));

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -1428,3 +1428,37 @@ function GetColor32( color32 )
 	t.alpha <- ((readColor >>> 24) & 0xFF);
 	return t;
 }
+
+function BarbedWire()
+{
+		local player = GetPlayerFromUserID(params.userid);
+		local wireX = player.GetOrigin().x;
+		local wireY = player.GetOrigin().y;
+		local wireZ = player.GetOrigin().z;
+		local wireAngleX = player.GetAngles().x;
+		local wireAngleY = player.GetAngles().y;
+		local wireName = "wire";
+		local wire = SpawnEntityFromTable("prop_dynamic",
+		{
+			targetname = wireName,
+			origin = Vector(wireX, wireY, wireZ+18),
+			angles = Vector(wireAngleX, wireAngleY, 0)
+			model = "models/props_street/concertinawire128_rusty.mdl",
+			solid = 0,
+			disableshadows = 1,
+		});
+		local wireTrigger = SpawnEntityFromTable("trigger_hurt",
+		{
+			targetname = wireName + "_trigger",
+			origin = Vector(wireX, wireY, wireZ+18),
+			angles = Vector(wireAngleX, wireAngleY, 0)
+			damagetype = 0,
+			damage = 25,
+			spawnflags = 3,
+			filtername = "__swarm_filter_infected"
+		});
+		// Set up trigger
+		DoEntFire("!self", "AddOutput", "mins -44 -44 0", 0, null, wireTrigger);
+		DoEntFire("!self", "AddOutput", "maxs 44 44 28", 0, null, wireTrigger);
+		DoEntFire("!self", "AddOutput", "solid 2", 0, null, wireTrigger);
+}

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -808,7 +808,8 @@ function PlayerHurt(params)
 				if (params.type == 2 && params.health < boss_health)
 				{
 					//Stagger tank
-					player.Stagger(Vector(0, 0, 0));
+					player.Stagger(Vector(-1, -1, -1));
+					boss_health = player.GetHealth() / 4;
 				}
 			}
 		}
@@ -1401,7 +1402,7 @@ function CreateSurvivorFilter()
 }
 CreateSurvivorFilter();
 
-/*function CreateInfectedFilter()
+function CreateInfectedFilter()
 {
 	SpawnEntityFromTable("filter_activator_team",
 	{
@@ -1409,7 +1410,8 @@ CreateSurvivorFilter();
 		Negated = "Allow entities that match criteria",
 		filterteam = 3
 	});
-}*/
+}
+CreateInfectedFilter();
 
 // From VSLib - Get rendercolor of a prop
 /**
@@ -1429,36 +1431,85 @@ function GetColor32( color32 )
 	return t;
 }
 
-function BarbedWire()
+
+function BarbedWire(params)
 {
-		local player = GetPlayerFromUserID(params.userid);
-		local wireX = player.GetOrigin().x;
-		local wireY = player.GetOrigin().y;
-		local wireZ = player.GetOrigin().z;
-		local wireAngleX = player.GetAngles().x;
-		local wireAngleY = player.GetAngles().y;
-		local wireName = "wire";
-		local wire = SpawnEntityFromTable("prop_dynamic",
-		{
-			targetname = wireName,
-			origin = Vector(wireX, wireY, wireZ+18),
-			angles = Vector(wireAngleX, wireAngleY, 0)
-			model = "models/props_street/concertinawire128_rusty.mdl",
-			solid = 0,
-			disableshadows = 1,
-		});
-		local wireTrigger = SpawnEntityFromTable("trigger_hurt",
-		{
-			targetname = wireName + "_trigger",
-			origin = Vector(wireX, wireY, wireZ+18),
-			angles = Vector(wireAngleX, wireAngleY, 0)
-			damagetype = 0,
-			damage = 25,
-			spawnflags = 3,
-			filtername = "__swarm_filter_infected"
-		});
-		// Set up trigger
-		DoEntFire("!self", "AddOutput", "mins -44 -44 0", 0, null, wireTrigger);
-		DoEntFire("!self", "AddOutput", "maxs 44 44 28", 0, null, wireTrigger);
-		DoEntFire("!self", "AddOutput", "solid 2", 0, null, wireTrigger);
+	local ItemstoRemove_ModelPaths =
+	[
+		"models/props/terror/incendiary_ammo.mdl",
+		"models/props/terror/exploding_ammo.mdl",
+	];
+
+	local player = GetPlayerFromUserID(params.userid);
+	local wireX = player.GetOrigin().x;
+	local wireY = player.GetOrigin().y;
+	local wireZ = player.GetOrigin().z;
+	local wireAngleX = player.GetAngles().x;
+	local wireAngleY = player.GetAngles().y;
+	local wireName = "wire";
+	local wire = SpawnEntityFromTable("prop_dynamic",
+	{
+		targetname = wireName,
+		origin = Vector(wireX, wireY, wireZ+18),
+		angles = Vector(wireAngleX, wireAngleY, 0)
+		model = "models/props_street/concertinawire128_rusty.mdl",
+		solid = 0,
+		disableshadows = 1,
+	});
+	local wireTrigger = SpawnEntityFromTable("trigger_hurt",
+	{
+		targetname = wireName + "_trigger",
+		origin = Vector(wireX, wireY, wireZ),
+		angles = Vector(wireAngleX, wireAngleY, 0)
+		damagetype = 0,
+		damage = 25,
+		spawnflags = 3,
+		filtername = "__swarm_filter_infected"
+	});
+
+	// Set up trigger
+	DoEntFire("!self", "AddOutput", "mins -44 -44 0", 0, null, wireTrigger);
+	DoEntFire("!self", "AddOutput", "maxs 44 44 28", 0, null, wireTrigger);
+	DoEntFire("!self", "AddOutput", "solid 0", 0, null, wireTrigger);
+	// Remove ammo pack model
+	foreach(modelpath in ItemstoRemove_ModelPaths)
+	{
+		local weapon_ent = null;
+		while(weapon_ent = Entities.FindByModel(weapon_ent, modelpath))
+			weapon_ent.Kill();
+	}
+}
+
+function AmmoPack(params)
+{
+	local ItemstoRemove_ModelPaths =
+	[
+		"models/props/terror/incendiary_ammo.mdl",
+		"models/props/terror/exploding_ammo.mdl",
+	];
+
+	local player = GetPlayerFromUserID(params.userid);
+	local ammoX = player.GetOrigin().x;
+	local ammoY = player.GetOrigin().y;
+	local ammoZ = player.GetOrigin().z;
+	local ammoAngleX = player.GetAngles().x;
+	local ammoAngleY = player.GetAngles().y;
+	local ammoName = "ammoPile";
+	local ammoPile = SpawnEntityFromTable("weapon_ammo_spawn",
+	{
+		targetname = ammoName,
+		origin = Vector(ammoX, ammoY, ammoZ),
+		angles = Vector(ammoAngleX, ammoAngleY, 0)
+		model = "models/props/terror/ammo_stack.mdl",
+		solid = 0,
+		disableshadows = 1,
+	});
+
+	// Remove ammo pack model
+	foreach(modelpath in ItemstoRemove_ModelPaths)
+	{
+		local weapon_ent = null;
+		while(weapon_ent = Entities.FindByModel(weapon_ent, modelpath))
+			weapon_ent.Kill();
+	}
 }

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -813,6 +813,21 @@ function PlayerHurt(params)
 				}
 			}
 		}
+		if (player.IsSurvivor() == false)
+		{
+			if ("type" in params)
+			{
+				if (params.type == 8 && player.IsSurvivor() == false)
+				{
+					local time = Time();
+					local extinguish_time = 5;
+					if (time > extinguish_time)
+					{
+						player.Extinguish()
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -804,11 +804,11 @@ function PlayerHurt(params)
 		{
 			if ("type" in params)
 			{
-				if (params.type == 2 && params.health < stagger_dmg)
+				if (params.type == 2 && bossOgreEnable == true && params.health < stagger_dmg)
 				{
 					//Stagger tank
 					player.Stagger(Vector(-1, -1, -1));
-					stagger_dmg = player.GetHealth() / 4;
+					stagger_dmg = stagger_dmg / 4;
 				}
 			}
 		}


### PR DESCRIPTION
- Replaced upgrade packs with barbed wire that hurts infected. (needs world model replacement? buff dmg?)
- Added function to replace upgrade packs with an ammo pile. Need a way to distinguish incendiary/explosive packs until this is officially added.
- Ogre now staggers when enough damage is done @ 50% and 12.5% health (this still needs work but it seems to function)
- Fire now extinguishes on infected instead of damaging them til death.
- Buffed fire damage vs tank (TTK is roughly 4x faster).