### PR TITLE
Recalculate melee damage

### DIFF
--- a/scripts/vscripts/swarm/swarm_playercards_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_playercards_stocks.nut
@@ -56,7 +56,7 @@ brawnCards <-
 disciplineCards <-
 [
 	"StrengthInNumbers",
-	//"NoHead",
+	//"BOOM",
 	"FireProof",
 	//"HunkerDown",
 	//"SoftenUp",
@@ -540,8 +540,8 @@ function GetPlayerCardName(cardID, type = "name")
 				case "StrengthInNumbers":
 					return "Strength In Numbers";
 					break;
-				case "NoHead":
-					return "So No Head?";
+				case "BOOM":
+					return "BOOM!";
 					break;
 				case "FireProof":
 					return "Fire Proof";
@@ -813,8 +813,8 @@ function GetPlayerCardName(cardID, type = "name")
 				case "StrengthInNumbers":
 					return "Strength In Numbers";
 					break;
-				case "NoHead":
-					return "So No Head?";
+				case "BOOM":
+					return "BOOM!";
 					break;
 				case "FireProof":
 					return "Fire Proof";
@@ -1089,7 +1089,7 @@ function GetPlayerCardName(cardID, type = "name")
 				case "StrengthInNumbers":
 					return "+2.5% Team DMG per alive Cleaner";
 					break;
-				case "NoHead":
+				case "BOOM":
 					return "Headshot kills cause an explosion";
 					break;
 				case "FireProof":
@@ -1362,7 +1362,7 @@ function GetPlayerCardName(cardID, type = "name")
 				case "StrengthInNumbers":
 					return "+2.5% Team DMG per alive Cleaner";
 					break;
-				case "NoHead":
+				case "BOOM":
 					return "Headshot kills cause an explosion";
 					break;
 				case "FireProof":

--- a/scripts/vscripts/swarm/swarm_stocks.nut
+++ b/scripts/vscripts/swarm/swarm_stocks.nut
@@ -372,7 +372,7 @@ function AllowTakeDamage(damageTable)
 					
 					if (originalDamageDone != 0)
 					{
-						damageTable.DamageDone *= RecalculateMeleeDamage(victim);
+						damageTable.DamageDone *= (melee_damage.tofloat() / damageTable.DamageDone.tofloat()); //RecalculateMeleeDamage(victim, damageTable.DamageDone);
 					}
 				}
 
@@ -1365,7 +1365,7 @@ function WeaponFireM60(params)
  * 	}
  * 	return fResult;
 }*/
-function RecalculateMeleeDamage(victim)
+/*function RecalculateMeleeDamage(victim, damageDone)
 {
 	local result = 175.0;
 	local victimClass = null
@@ -1403,11 +1403,14 @@ function RecalculateMeleeDamage(victim)
 		break;
 	}
 
-	/*printl("melee_damage " + melee_damage);
-	printl("result " + result);*/
 
-	return melee_damage / result;
-}
+
+	printl("melee_damage " + melee_damage.tofloat());
+	printl("result " + result.tofloat());
+	printl("multi " + (melee_damage.tofloat() / result.tofloat()))
+
+	return melee_damage.tofloat() / result.tofloat();
+}*/
 
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
Melee now deals a static amount of damage (400)
Any multipliers still affect the damage, but the base damage will now always ignore the scaling depending on which type of infected is hit
Since the damage is always set to 400 body part multipliers are ignored so will need to be added in manually for melee specifically